### PR TITLE
chore: update tbp.monty==0.0.3

### DIFF
--- a/monty/environment.yml
+++ b/monty/environment.yml
@@ -26,7 +26,7 @@ channels:
   - thousandbrainsproject
 
 dependencies:
-  - thousandbrainsproject::tbp.monty==0.0.2
+  - thousandbrainsproject::tbp.monty==0.0.3
   - pip
   - pip:
     - -e .[dev]


### PR DESCRIPTION
With `tbp.monty==0.0.2`, it was possible to install a `numpy` version that did not have `np.long` expected by the code. This pull request pins the Monty dependency to `tbp.monty==0.0.3`, which is updated to require the appropriate version of `numpy` as updated in https://github.com/thousandbrainsproject/tbp.monty/pull/211.