### PR TITLE
chore: update tbp.monty==0.1.0

### DIFF
--- a/monty/environment.yml
+++ b/monty/environment.yml
@@ -26,7 +26,7 @@ channels:
   - thousandbrainsproject
 
 dependencies:
-  - thousandbrainsproject::tbp.monty==0.0.3
+  - thousandbrainsproject::tbp.monty==0.1.0
   - pip
   - pip:
     - -e .[dev]


### PR DESCRIPTION
Updating to the latest `tbp.monty` release: https://github.com/thousandbrainsproject/tbp.monty/pull/225.