### PR TITLE
refactor: remove unnecessary blank lines after docstring

### DIFF
--- a/monty/configs/common.py
+++ b/monty/configs/common.py
@@ -318,7 +318,6 @@ def make_randrot_variant(
     Returns:
         An experiment config that uses the 5 predefined random rotations.
     """
-
     config = deepcopy(template)
 
     # Optionally, use the provided run name. Otherwise, append "_randrot" to the
@@ -355,7 +354,6 @@ def make_randrot_noise_variant(
         An experiment config that uses the 5 predefined random rotations and has
         added sensor noise.
     """
-
     config = make_randrot_variant(template)
     config = make_noise_variant(config, run_name=run_name)
     return config
@@ -472,7 +470,6 @@ class SelectiveEvidenceHandler(DetailedJSONHandler):
         Returns:
             Tuple[int, Mapping]: The episode number and the data to save.
         """
-
         # Get basic and detailed data.
         if mode == "train":
             episode_total = kwargs["train_episodes_to_total"][episode]

--- a/monty/configs/fig4_structured_object_representations.py
+++ b/monty/configs/fig4_structured_object_representations.py
@@ -54,7 +54,6 @@ class LastMaxEvidenceHandler(SelectiveEvidenceHandler):
         **kwargs,
     ) -> None:
         """Store only maxima of final evidence values."""
-
         # Initialize output data.
         episode_total, buffer_data = self.init_buffer_data(
             data, episode, mode, **kwargs

--- a/monty/configs/pretraining_experiments.py
+++ b/monty/configs/pretraining_experiments.py
@@ -160,7 +160,6 @@ def get_pretrain_patch_config(agent_type: str) -> Dict[str, Any]:
     Returns:
         dict: Configuration dictionary for the surface patch sensor module.
     """
-
     if agent_type == "dist":
         return dict(
             sensor_module_class=HabitatDistantPatchSM,

--- a/monty/configs/view_finder_images.py
+++ b/monty/configs/view_finder_images.py
@@ -147,7 +147,6 @@ class ViewFinderRGBDHandler(MontyHandler):
             episode (int): The current episode number.
             mode (str): The mode (train or eval).
         """
-
         if not self.initialized:
             self.initialize(data, output_dir, episode, mode, **kwargs)
 

--- a/monty/configs/visualizations.py
+++ b/monty/configs/visualizations.py
@@ -142,7 +142,6 @@ class MLHEvidenceHandler(SelectiveEvidenceHandler):
         **kwargs,
     ) -> None:
         """Store only final evidence data and no sensor data."""
-
         # Initialize output data.
         episode_total, buffer_data = self.init_buffer_data(
             data, episode, mode, **kwargs
@@ -268,7 +267,6 @@ class HypothesisDrivenPolicyEvidenceHandler(SelectiveEvidenceHandler):
         **kwargs,
     ) -> None:
         """Store only final evidence data and no sensor data."""
-
         # Initialize output data.
         episode_total, buffer_data = self.init_buffer_data(
             data, episode, mode, **kwargs

--- a/scripts/data_utils.py
+++ b/scripts/data_utils.py
@@ -61,7 +61,6 @@ def load_eval_stats(exp: os.PathLike) -> pd.DataFrame:
     Returns:
         pd.DataFrame
     """
-
     path = Path(exp).expanduser()
 
     if path.exists():

--- a/scripts/fig2.py
+++ b/scripts/fig2.py
@@ -68,7 +68,6 @@ def plot_object_views(
         vmin: The minimum value for the gradient background.
         vmax: The maximum value for the gradient background.
     """
-
     # Initialize input and output paths.
     data_dir = VIEW_FINDER_DIR / "view_finder_base_highres/view_finder_rgbd"
     png_dir = OUT_DIR / f"object_views/{object_name}/png"

--- a/scripts/fig4.py
+++ b/scripts/fig4.py
@@ -259,7 +259,6 @@ def get_relative_evidence_matrices() -> np.ndarray:
         matrix is the relative evidence matrix for the corresponding epoch.
 
     """
-
     exp_dir = DMC_RESULTS_DIR / "surf_agent_1lm_randrot_noise_10simobj"
     eval_stats = load_eval_stats(exp_dir / "eval_stats.csv")
     detailed_stats = DetailedJSONStatsInterface(exp_dir / "detailed_run_stats.json")
@@ -294,7 +293,6 @@ def load_symmetry_rotations(stats: Mapping) -> List[SimpleNamespace]:
        A list of SimpleNamespace objects, each representing a symmetric rotation.
 
     """
-
     # Get MLH object name -- symmetric rotations are only computed for the MLH object.
     object_name = stats["LM_0"]["current_mlh"][-1]["graph_id"]
 
@@ -353,7 +351,6 @@ def plot_dendrogram():
 
     NOTE: Also plots a confusion matrix, which is not used in the paper.
     """
-
     out_dir = OUT_DIR / "dendrogram"
     out_dir.mkdir(parents=True, exist_ok=True)
 

--- a/scripts/fig5.py
+++ b/scripts/fig5.py
@@ -365,7 +365,6 @@ def plot_accuracy():
     Output is saved to `DMC_ANALYSIS_DIR/fig5/performance`.
 
     """
-
     # Initialize output directory.
     out_dir = OUT_DIR / "performance"
     out_dir.mkdir(exist_ok=True, parents=True)

--- a/scripts/overview.py
+++ b/scripts/overview.py
@@ -165,7 +165,6 @@ def init_overview_plot(
     Returns:
         matplotlib.figure.Figure: Summary plot.
     """
-
     fig, axes = plt.subplots(1, 3, figsize=figsize)
     xticks = list(range(len(conditions)))
     # Plot distribution of num_steps

--- a/scripts/plot_utils.py
+++ b/scripts/plot_utils.py
@@ -112,7 +112,6 @@ def axes3d_clean(ax: Axes3D, grid: bool = True) -> None:
         ax: The 3D axes to clean.
         grid: Whether to show the background grid. Default is True.
     """
-
     # Remove dark spines that outline the plot.
     for axis in (ax.xaxis, ax.yaxis, ax.zaxis):
         axis.line.set_color((1, 1, 1, 0))
@@ -188,7 +187,6 @@ def add_gradient_background(
     vmax: float = 0.9,
 ) -> np.ndarray:
     """Add a grayscale gradient background to an RGBA image."""
-
     width, height = image.shape[0], image.shape[1]
 
     # First, create the gradient background.
@@ -302,7 +300,6 @@ def violinplot(
     Returns:
         plt.Axes: The axes containing the violin plot
     """
-
     # Move positions and shrink widths if we're doing half violins.
     if side == "both":
         offset = 0

--- a/scripts/render_view_finder_images.py
+++ b/scripts/render_view_finder_images.py
@@ -104,7 +104,6 @@ def parse_args():
 
 def render_figures(experiment: str) -> None:
     """Render figures for each object showing its rotations"""
-
     # Initialize storage directory.
     data_dir = VIEW_FINDER_DIR / f"{experiment}/view_finder_rgbd"
     visualization_dir = data_dir / "visualizations"


### PR DESCRIPTION
Removed extra blank lines after docstring as per Ruff rule [D202](https://docs.astral.sh/ruff/rules/blank-line-after-function/).