### PR TITLE
refactor: add period to first line of docstrings (D415)

### DIFF
--- a/monty/configs/fig4_structured_object_representations.py
+++ b/monty/configs/fig4_structured_object_representations.py
@@ -7,7 +7,7 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-"""Configs for Figure 4: Structured Object Representations
+"""Configs for Figure 4: Structured Object Representations.
 
 This module defines the following experiment:
  - `surf_agent_1lm_randrot_noise_10simobj`

--- a/monty/configs/fig7_rapid_learning.py
+++ b/monty/configs/fig7_rapid_learning.py
@@ -6,7 +6,7 @@
 # Use of this source code is governed by the MIT
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
-"""Figure 7: Rapid Learning
+"""Figure 7: Rapid Learning.
 
 Consists of one pretraining experiment and 6 evaluation experiments:
 - pretrain_dist_agent_1lm_checkpoints

--- a/monty/configs/view_finder_images.py
+++ b/monty/configs/view_finder_images.py
@@ -182,7 +182,7 @@ class ViewFinderRGBDHandler(MontyHandler):
 
 
 class FramedObjectPolicy(InformedPolicy):
-    """Custom motor policy that helps keep the object in-frame
+    """Custom motor policy that helps keep the object in-frame.
 
     Reimplements `InformedPolicy.move_close_enough` to add an extra termination
     condition: if the object enters a small buffer region in the view-finder's

--- a/monty/configs/visualizations.py
+++ b/monty/configs/visualizations.py
@@ -6,7 +6,7 @@
 # Use of this source code is governed by the MIT
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
-"""Configs for visualizations (not core experiments)
+"""Configs for visualizations (not core experiments).
 
 This file contains configs defined solely for making visualizations that go into
 paper figures. The configs defined are:

--- a/scripts/render_view_finder_images.py
+++ b/scripts/render_view_finder_images.py
@@ -103,7 +103,7 @@ def parse_args():
 
 
 def render_figures(experiment: str) -> None:
-    """Render figures for each object showing its rotations"""
+    """Render figures for each object showing its rotations."""
     # Initialize storage directory.
     data_dir = VIEW_FINDER_DIR / f"{experiment}/view_finder_rgbd"
     visualization_dir = data_dir / "visualizations"


### PR DESCRIPTION
"The first line of a docstring should end with a period, question mark, or exclamation point, for grammatical correctness and consistency." as per [D415](https://docs.astral.sh/ruff/rules/missing-terminal-punctuation/).