### PR TITLE
Fix pretraining config for surface agent

### DIFF
--- a/monty/configs/pretraining_experiments.py
+++ b/monty/configs/pretraining_experiments.py
@@ -125,7 +125,7 @@ def get_pretrain_lm_config(agent_type: str) -> Dict[str, Any]:
     if agent_type == "dist":
         graph_delta_distance_threshold = 0.001
     elif agent_type == "surf":
-        graph_delta_distance_threshold = 0.0001
+        graph_delta_distance_threshold = 0.01
     else:
         raise ValueError(f"Invalid agent_type: {agent_type}. Must be 'dist' or 'surf'.")
 


### PR DESCRIPTION
I got a parameter wrong when consolidating config getter function. This is a one line fix to restore the original parameter. This change returns the results of visualization experiments to their behavior prior to migrating to `tbp.tbs_sensorimotor_intelligence`.
