### PR TITLE
fix: correct noise parameters specification and noise parameters for some experiments

### DIFF
--- a/monty/configs/README.md
+++ b/monty/configs/README.md
@@ -17,7 +17,7 @@ to run an experiment in parallel.
 
 ## Figure 3: Robust Sensorimotor Inference
 
-This figure presents results from four inference experiments testing Monty's robustness under different conditions. Monty was pre-trained on 14 standard rotations derived from cube face and corner views (see full configuration details in `pretraining_experiments/dist_agent_1lm`).
+This figure presents results from five inference experiments testing Monty's robustness under different conditions. Monty was pre-trained on 14 standard rotations derived from cube face and corner views (see full configuration details in `pretraining_experiments/dist_agent_1lm`).
 
 - `dist_agent_1lm`: Standard inference with no sensor noise or random rotations
 - `dist_agent_1lm_noise_all`: Tests robustness to heavy sensor noise
@@ -50,7 +50,6 @@ The main output measure is a dendrogram showing evidence score clustering for th
 
 **Notes:**
 - Although evaluating on 10 objects, the model is trained on 77 objects.
-- We need to run this experiment with SELECTIVE logging on so we get the evidence values to analyze.
   
 ## Default Parameters for Figures 5+
 Unless specified otherwise, the following figures/experiments use:

--- a/monty/configs/README.md
+++ b/monty/configs/README.md
@@ -20,17 +20,19 @@ to run an experiment in parallel.
 This figure presents results from four inference experiments testing Monty's robustness under different conditions. Monty was pre-trained on 14 standard rotations derived from cube face and corner views (see full configuration details in `pretraining_experiments/dist_agent_1lm`).
 
 - `dist_agent_1lm`: Standard inference with no sensor noise or random rotations
-- `dist_agent_1lm_noise`: Tests robustness to sensor noise
-- `dist_agent_1lm_randrot_all`: Tests performance across 14 random rotations, not seen during training
-- `dist_agent_1lm_randrot_all_noise`: Tests performance with both random rotations and sensor noise
-
+- `dist_agent_1lm_noise_all`: Tests robustness to heavy sensor noise
+- `dist_agent_1lm_randrot_14`: Tests performance across 14 random rotations, not seen during training
+- `dist_agent_1lm_randrot_14_noise_all`: Tests performance with both random rotations and heavy sensor noise
+- `dist_agent_1lm_randrot_14_noise_all_color_clamped`: Tests performance with random rotations, heavy sensor noise, and with the color feature for each observation clamped
+to blue.
+  
 Here we are showing the performance of the "standard" version of Monty, using:
 - 77 objects
 - 14 rotations
 - Goal-state-driven/hypothesis-testing policy active
 - A single LM (no voting)
 
-The main output measures are accuracy, rotation error (degrees), and Chamfer distance for each condition.
+The main output measures are accuracy and rotation error (degrees) for each condition.
 
 ## Figure 4: Structured Object Representations
 

--- a/monty/configs/common.py
+++ b/monty/configs/common.py
@@ -257,10 +257,12 @@ def add_sensor_noise(config: Dict[str, Any]) -> None:
         config: Experiment config to add sensor noise to.
     """
     noise_params = {
-        "pose_vectors": 2.0,
-        "hsv": 0.1,
-        "principal_curvatures_log": 0.1,
-        "pose_fully_defined": 0.01,
+        "features": {
+            "pose_vectors": 2.0,
+            "hsv": 0.1,
+            "principal_curvatures_log": 0.1,
+            "pose_fully_defined": 0.01,
+        },
         "location": 0.002,
     }
 

--- a/monty/configs/common.py
+++ b/monty/configs/common.py
@@ -248,7 +248,7 @@ Functions for generating variations of existing configs.
 """
 
 
-def add_sensor_noise(config: Dict[str, Any]) -> None:
+def add_sensor_noise(config: Dict[str, Any], noise_params: Dict[str, Any]) -> None:
     """Add sensor noise to an experiment config. Modifies the config in-place.
 
     Applies noise parameters to all sensor modules except the view finder.
@@ -256,25 +256,16 @@ def add_sensor_noise(config: Dict[str, Any]) -> None:
     Args:
         config: Experiment config to add sensor noise to.
     """
-    noise_params = {
-        "features": {
-            "pose_vectors": 2.0,
-            "hsv": 0.1,
-            "principal_curvatures_log": 0.1,
-            "pose_fully_defined": 0.01,
-        },
-        "location": 0.002,
-    }
-
     for sm_dict in config["monty_config"].sensor_module_configs.values():
         sm_args = sm_dict["sensor_module_args"]
         if sm_args["sensor_module_id"] == "view_finder":
             continue
-        sm_args["noise_params"] = noise_params
+        sm_args["noise_params"] = deepcopy(noise_params)
 
 
 def make_noise_variant(
     template: Dict[str, Any],
+    noise_params: Dict[str, Any],
     run_name: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Create a copy of an experiment config with added sensor noise.
@@ -300,7 +291,7 @@ def make_noise_variant(
             config["logging_config"].run_name = f"{template_name}_noise"
 
     # Add sensor noise. Modifies `config` in-place.
-    add_sensor_noise(config)
+    add_sensor_noise(config, noise_params)
 
     return config
 
@@ -342,6 +333,7 @@ def make_randrot_variant(
 
 def make_randrot_noise_variant(
     template: Dict[str, Any],
+    noise_params: Dict[str, Any],
     run_name: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Create a copy of an experiment config w/ sensor noise and  5 random rotations.
@@ -357,7 +349,7 @@ def make_randrot_noise_variant(
         added sensor noise.
     """
     config = make_randrot_variant(template)
-    config = make_noise_variant(config, run_name=run_name)
+    config = make_noise_variant(config, noise_params, run_name=run_name)
     return config
 
 

--- a/monty/configs/fig3_robust_sensorimotor_inference.py
+++ b/monty/configs/fig3_robust_sensorimotor_inference.py
@@ -157,6 +157,15 @@ dist_agent_1lm_randrot_14_noise_all_color_clamped["monty_config"].sensor_module_
     "sensor_module_0"
 ]["sensor_module_class"] = ClampedColorSM
 
+# no noise - temp
+dist_agent_1lm_randrot_14_color_clamped = deepcopy(dist_agent_1lm_randrot_14)
+dist_agent_1lm_randrot_14_color_clamped[
+    "logging_config"
+].run_name = "dist_agent_1lm_randrot_14_color_clamped"
+
+dist_agent_1lm_randrot_14_color_clamped["monty_config"].sensor_module_configs[
+    "sensor_module_0"
+]["sensor_module_class"] = ClampedColorSM
 
 CONFIGS = {
     "dist_agent_1lm": dist_agent_1lm,
@@ -164,4 +173,5 @@ CONFIGS = {
     "dist_agent_1lm_randrot_14": dist_agent_1lm_randrot_14,
     "dist_agent_1lm_randrot_14_noise_all": dist_agent_1lm_randrot_14_noise_all,
     "dist_agent_1lm_randrot_14_noise_all_color_clamped": dist_agent_1lm_randrot_14_noise_all_color_clamped,
+    "dist_agent_1lm_randrot_14_color_clamped": dist_agent_1lm_randrot_14_color_clamped,
 }

--- a/monty/configs/fig3_robust_sensorimotor_inference.py
+++ b/monty/configs/fig3_robust_sensorimotor_inference.py
@@ -28,6 +28,7 @@ is defined in `fig5_rapid_inference_with_voting.py`.
 
 from copy import deepcopy
 
+import numpy as np
 from tbp.monty.frameworks.config_utils.config_args import (
     MontyArgs,
     PatchAndViewMontyConfig,
@@ -45,6 +46,7 @@ from tbp.monty.frameworks.experiments import MontyObjectRecognitionExperiment
 from tbp.monty.frameworks.models.evidence_matching import (
     MontyForEvidenceGraphMatching,
 )
+from tbp.monty.frameworks.models.sensor_modules import FeatureChangeSM
 from tbp.monty.simulators.habitat.configs import (
     PatchViewFinderMountHabitatDatasetArgs,
 )
@@ -131,10 +133,34 @@ dist_agent_1lm_randrot_all_heavy_noise = make_noise_variant(
     run_name="dist_agent_1lm_randrot_all_heavy_noise",
 )
 
+class ClampedColorSM(FeatureChangeSM):
+    """Sensor module that clamps the hsv feature to blue."""
+
+    def step(self, data):
+        """Return Features if they changed significantly."""
+        patch_observation = super().step(data)  # get extracted features
+        patch_observation.non_morphological_features["hsv"] = np.array(
+            [0.667, 1.0, 1.0]
+        )
+        return patch_observation
+
+
+dist_agent_1lm_randrot_all_heavy_noise_color_clamped = deepcopy(
+    dist_agent_1lm_randrot_all_heavy_noise
+)
+dist_agent_1lm_randrot_all_heavy_noise_color_clamped[
+    "logging_config"
+].run_name = "dist_agent_1lm_randrot_all_heavy_noise_color_clamped"
+
+dist_agent_1lm_randrot_all_heavy_noise_color_clamped[
+    "monty_config"
+].sensor_module_configs["sensor_module_0"]["sensor_module_class"] = ClampedColorSM
+
 
 CONFIGS = {
     "dist_agent_1lm": dist_agent_1lm,
     "dist_agent_1lm_heavy_noise": dist_agent_1lm_heavy_noise,
     "dist_agent_1lm_randrot_all": dist_agent_1lm_randrot_all,
     "dist_agent_1lm_randrot_all_heavy_noise": dist_agent_1lm_randrot_all_heavy_noise,
+    "dist_agent_1lm_randrot_all_heavy_noise_color_clamped": dist_agent_1lm_randrot_all_heavy_noise_color_clamped,
 }

--- a/monty/configs/fig3_robust_sensorimotor_inference.py
+++ b/monty/configs/fig3_robust_sensorimotor_inference.py
@@ -100,8 +100,22 @@ dist_agent_1lm = dict(
 # Noisy/random rotation variants
 # ------------------------------------------------------------------------------
 
+heavy_noise_params = {
+    "location": 0.002,
+    "features": {
+        "pose_vectors": 2.0,
+        "hsv": 0.1,
+        "principal_curvatures_log": 0.1,
+        "pose_fully_defined": 0.01,
+    },
+}
+
 # - Noisy sensor variant
-dist_agent_1lm_noise = make_noise_variant(dist_agent_1lm)
+dist_agent_1lm_heavy_noise = make_noise_variant(
+    dist_agent_1lm,
+    heavy_noise_params,
+    run_name="dist_agent_1lm_heavy_noise",
+)
 
 # - Random rotation variant (14 random rotations)
 dist_agent_1lm_randrot_all = deepcopy(dist_agent_1lm)
@@ -111,13 +125,16 @@ dist_agent_1lm_randrot_all[
 ].object_init_sampler = RandomRotationObjectInitializer()
 
 # - Random rotation variant (14 random rotations) and sensor noise
-dist_agent_1lm_randrot_all_noise = make_noise_variant(
-    dist_agent_1lm_randrot_all, run_name="dist_agent_1lm_randrot_all_noise"
+dist_agent_1lm_randrot_all_heavy_noise = make_noise_variant(
+    dist_agent_1lm_randrot_all,
+    heavy_noise_params,
+    run_name="dist_agent_1lm_randrot_all_heavy_noise",
 )
+
 
 CONFIGS = {
     "dist_agent_1lm": dist_agent_1lm,
-    "dist_agent_1lm_noise": dist_agent_1lm_noise,
+    "dist_agent_1lm_heavy_noise": dist_agent_1lm_heavy_noise,
     "dist_agent_1lm_randrot_all": dist_agent_1lm_randrot_all,
-    "dist_agent_1lm_randrot_all_noise": dist_agent_1lm_randrot_all_noise,
+    "dist_agent_1lm_randrot_all_heavy_noise": dist_agent_1lm_randrot_all_heavy_noise,
 }

--- a/monty/configs/fig3_robust_sensorimotor_inference.py
+++ b/monty/configs/fig3_robust_sensorimotor_inference.py
@@ -138,7 +138,7 @@ class ClampedColorSM(FeatureChangeSM):
     """Sensor module that clamps the hsv feature to blue."""
 
     def step(self, data):
-        """Return Features if they changed significantly."""
+        """Clamp hsv to solid blue if the observation is usable."""
         # Extract features.
         patch_observation = super().step(data)
         # Force hsv to solid blue.

--- a/monty/configs/fig3_robust_sensorimotor_inference.py
+++ b/monty/configs/fig3_robust_sensorimotor_inference.py
@@ -11,9 +11,10 @@
 
 This module defines the following experiments:
  - `dist_agent_1lm`
- - `dist_agent_1lm_noise`
- - `dist_agent_1lm_randrot_all`
- - `dist_agent_1lm_randrot_all_noise`
+ - `dist_agent_1lm_noise_all`
+ - `dist_agent_1lm_randrot_14`
+ - `dist_agent_1lm_randrot_14_noise_all`
+ - `dist_agent_1lm_randrot_14_noise_all_color_clamped`
 
  Experiments use:
  - 77 objects
@@ -102,7 +103,7 @@ dist_agent_1lm = dict(
 # Noisy/random rotation variants
 # ------------------------------------------------------------------------------
 
-heavy_noise_params = {
+all_noise_params = {
     "location": 0.002,
     "features": {
         "pose_vectors": 2.0,
@@ -113,24 +114,24 @@ heavy_noise_params = {
 }
 
 # - Noisy sensor variant
-dist_agent_1lm_heavy_noise = make_noise_variant(
+dist_agent_1lm_noise_all = make_noise_variant(
     dist_agent_1lm,
-    heavy_noise_params,
-    run_name="dist_agent_1lm_heavy_noise",
+    all_noise_params,
+    run_name="dist_agent_1lm_noise_all",
 )
 
 # - Random rotation variant (14 random rotations)
-dist_agent_1lm_randrot_all = deepcopy(dist_agent_1lm)
-dist_agent_1lm_randrot_all["logging_config"].run_name = "dist_agent_1lm_randrot_all"
-dist_agent_1lm_randrot_all[
+dist_agent_1lm_randrot_14 = deepcopy(dist_agent_1lm)
+dist_agent_1lm_randrot_14["logging_config"].run_name = "dist_agent_1lm_randrot_14"
+dist_agent_1lm_randrot_14[
     "eval_dataloader_args"
 ].object_init_sampler = RandomRotationObjectInitializer()
 
 # - Random rotation variant (14 random rotations) and sensor noise
-dist_agent_1lm_randrot_all_heavy_noise = make_noise_variant(
-    dist_agent_1lm_randrot_all,
-    heavy_noise_params,
-    run_name="dist_agent_1lm_randrot_all_heavy_noise",
+dist_agent_1lm_randrot_14_noise_all = make_noise_variant(
+    dist_agent_1lm_randrot_14,
+    all_noise_params,
+    run_name="dist_agent_1lm_randrot_14_noise_all",
 )
 
 class ClampedColorSM(FeatureChangeSM):
@@ -145,22 +146,22 @@ class ClampedColorSM(FeatureChangeSM):
         return patch_observation
 
 
-dist_agent_1lm_randrot_all_heavy_noise_color_clamped = deepcopy(
-    dist_agent_1lm_randrot_all_heavy_noise
+dist_agent_1lm_randrot_14_noise_all_color_clamped = deepcopy(
+    dist_agent_1lm_randrot_14_noise_all
 )
-dist_agent_1lm_randrot_all_heavy_noise_color_clamped[
+dist_agent_1lm_randrot_14_noise_all_color_clamped[
     "logging_config"
-].run_name = "dist_agent_1lm_randrot_all_heavy_noise_color_clamped"
+].run_name = "dist_agent_1lm_randrot_14_noise_all_color_clamped"
 
-dist_agent_1lm_randrot_all_heavy_noise_color_clamped[
-    "monty_config"
-].sensor_module_configs["sensor_module_0"]["sensor_module_class"] = ClampedColorSM
+dist_agent_1lm_randrot_14_noise_all_color_clamped["monty_config"].sensor_module_configs[
+    "sensor_module_0"
+]["sensor_module_class"] = ClampedColorSM
 
 
 CONFIGS = {
     "dist_agent_1lm": dist_agent_1lm,
-    "dist_agent_1lm_heavy_noise": dist_agent_1lm_heavy_noise,
-    "dist_agent_1lm_randrot_all": dist_agent_1lm_randrot_all,
-    "dist_agent_1lm_randrot_all_heavy_noise": dist_agent_1lm_randrot_all_heavy_noise,
-    "dist_agent_1lm_randrot_all_heavy_noise_color_clamped": dist_agent_1lm_randrot_all_heavy_noise_color_clamped,
+    "dist_agent_1lm_noise_all": dist_agent_1lm_noise_all,
+    "dist_agent_1lm_randrot_14": dist_agent_1lm_randrot_14,
+    "dist_agent_1lm_randrot_14_noise_all": dist_agent_1lm_randrot_14_noise_all,
+    "dist_agent_1lm_randrot_14_noise_all_color_clamped": dist_agent_1lm_randrot_14_noise_all_color_clamped,
 }

--- a/monty/configs/fig3_robust_sensorimotor_inference.py
+++ b/monty/configs/fig3_robust_sensorimotor_inference.py
@@ -141,7 +141,12 @@ class ClampedColorSM(FeatureChangeSM):
         """Return Features if they changed significantly."""
         patch_observation = super().step(data)  # get extracted features
         if "hsv" in patch_observation.non_morphological_features:
-            patch_observation.non_morphological_features["hsv"][0] = 0.667
+            # hsv clamping
+            patch_observation.non_morphological_features["hsv"] = np.array(
+                [0.667, 1.0, 1.0]
+            )
+            # hue clamping
+            # patch_observation.non_morphological_features["hsv"][0] = 0.667
         return patch_observation
 
 

--- a/monty/configs/fig3_robust_sensorimotor_inference.py
+++ b/monty/configs/fig3_robust_sensorimotor_inference.py
@@ -140,9 +140,8 @@ class ClampedColorSM(FeatureChangeSM):
     def step(self, data):
         """Return Features if they changed significantly."""
         patch_observation = super().step(data)  # get extracted features
-        patch_observation.non_morphological_features["hsv"] = np.array(
-            [0.667, 1.0, 1.0]
-        )
+        if "hsv" in patch_observation.non_morphological_features:
+            patch_observation.non_morphological_features["hsv"][0] = 0.667
         return patch_observation
 
 

--- a/monty/configs/fig3_robust_sensorimotor_inference.py
+++ b/monty/configs/fig3_robust_sensorimotor_inference.py
@@ -139,17 +139,18 @@ class ClampedColorSM(FeatureChangeSM):
 
     def step(self, data):
         """Return Features if they changed significantly."""
-        patch_observation = super().step(data)  # get extracted features
+        # Extract features.
+        patch_observation = super().step(data)
+        # Force hsv to solid blue.
         if "hsv" in patch_observation.non_morphological_features:
-            # hsv clamping
             patch_observation.non_morphological_features["hsv"] = np.array(
                 [0.667, 1.0, 1.0]
             )
-            # hue clamping
-            # patch_observation.non_morphological_features["hsv"][0] = 0.667
         return patch_observation
 
 
+# - Random rotation variant (14 random rotations) and sensor noise with
+#   the 'hsv' feature clamped to solid blue.
 dist_agent_1lm_randrot_14_noise_all_color_clamped = deepcopy(
     dist_agent_1lm_randrot_14_noise_all
 )
@@ -161,15 +162,6 @@ dist_agent_1lm_randrot_14_noise_all_color_clamped["monty_config"].sensor_module_
     "sensor_module_0"
 ]["sensor_module_class"] = ClampedColorSM
 
-# no noise - temp
-dist_agent_1lm_randrot_14_color_clamped = deepcopy(dist_agent_1lm_randrot_14)
-dist_agent_1lm_randrot_14_color_clamped[
-    "logging_config"
-].run_name = "dist_agent_1lm_randrot_14_color_clamped"
-
-dist_agent_1lm_randrot_14_color_clamped["monty_config"].sensor_module_configs[
-    "sensor_module_0"
-]["sensor_module_class"] = ClampedColorSM
 
 CONFIGS = {
     "dist_agent_1lm": dist_agent_1lm,
@@ -177,5 +169,4 @@ CONFIGS = {
     "dist_agent_1lm_randrot_14": dist_agent_1lm_randrot_14,
     "dist_agent_1lm_randrot_14_noise_all": dist_agent_1lm_randrot_14_noise_all,
     "dist_agent_1lm_randrot_14_noise_all_color_clamped": dist_agent_1lm_randrot_14_noise_all_color_clamped,
-    "dist_agent_1lm_randrot_14_color_clamped": dist_agent_1lm_randrot_14_color_clamped,
 }

--- a/monty/configs/fig3_robust_sensorimotor_inference.py
+++ b/monty/configs/fig3_robust_sensorimotor_inference.py
@@ -103,7 +103,7 @@ dist_agent_1lm = dict(
 # Noisy/random rotation variants
 # ------------------------------------------------------------------------------
 
-all_noise_params = {
+noise_all_params = {
     "location": 0.002,
     "features": {
         "pose_vectors": 2.0,
@@ -116,7 +116,7 @@ all_noise_params = {
 # - Noisy sensor variant
 dist_agent_1lm_noise_all = make_noise_variant(
     dist_agent_1lm,
-    all_noise_params,
+    noise_all_params,
     run_name="dist_agent_1lm_noise_all",
 )
 
@@ -130,7 +130,7 @@ dist_agent_1lm_randrot_14[
 # - Random rotation variant (14 random rotations) and sensor noise
 dist_agent_1lm_randrot_14_noise_all = make_noise_variant(
     dist_agent_1lm_randrot_14,
-    all_noise_params,
+    noise_all_params,
     run_name="dist_agent_1lm_randrot_14_noise_all",
 )
 

--- a/monty/configs/fig3_robust_sensorimotor_inference.py
+++ b/monty/configs/fig3_robust_sensorimotor_inference.py
@@ -142,10 +142,13 @@ class ClampedColorSM(FeatureChangeSM):
         # Extract features.
         patch_observation = super().step(data)
         # Force hsv to solid blue.
-        if "hsv" in patch_observation.non_morphological_features:
-            patch_observation.non_morphological_features["hsv"] = np.array(
-                [0.667, 1.0, 1.0]
-            )
+        if patch_observation.use_state:
+            if "hsv" in patch_observation.non_morphological_features:
+                patch_observation.non_morphological_features["hsv"] = np.array(
+                    [0.667, 1.0, 1.0]
+                )
+            else:
+                raise ValueError("hsv feature not found")
         return patch_observation
 
 

--- a/monty/configs/fig5_rapid_inference_with_voting.py
+++ b/monty/configs/fig5_rapid_inference_with_voting.py
@@ -114,13 +114,17 @@ def make_multi_lm_eval_config(num_lms: int) -> Mapping[str, Any]:
     )
 
     # Finally, add sensor noise.
-    add_sensor_noise(config)
+    add_sensor_noise(config, noise_params={"location": 0.002})
 
     return config
 
 
 # ==== The single-LM config ====
-dist_agent_1lm_randrot_noise = make_randrot_noise_variant(dist_agent_1lm)
+dist_agent_1lm_randrot_noise = make_randrot_noise_variant(
+    dist_agent_1lm,
+    noise_params={"location": 0.002},
+    run_name="dist_agent_1lm_randrot_noise",
+)
 
 # ==== Multi-LM configs ====
 

--- a/monty/configs/fig6_rapid_inference_with_model_based_policies.py
+++ b/monty/configs/fig6_rapid_inference_with_model_based_policies.py
@@ -101,7 +101,11 @@ dist_agent_1lm_randrot_noise_nohyp[
 
 
 # Surface agent: Standard hypothesis-testing
-surf_agent_1lm_randrot_noise = make_randrot_noise_variant(surf_agent_1lm)
+surf_agent_1lm_randrot_noise = make_randrot_noise_variant(
+    surf_agent_1lm,
+    noise_params={"location": 0.002},
+    run_name="surf_agent_1lm_randrot_noise",
+)
 
 # Surface agent: No hypothesis-testing
 surf_agent_1lm_randrot_noise_nohyp = deepcopy(surf_agent_1lm_randrot_noise)

--- a/monty/configs/visualizations.py
+++ b/monty/configs/visualizations.py
@@ -54,7 +54,7 @@ from .common import (
     SelectiveEvidenceHandler,
     SelectiveEvidenceLoggingConfig,
 )
-from .fig3_robust_sensorimotor_inference import dist_agent_1lm_heavy_noise
+from .fig3_robust_sensorimotor_inference import dist_agent_1lm_noise_all
 from .fig5_rapid_inference_with_voting import (
     dist_agent_1lm_randrot_noise,
     dist_agent_8lm_randrot_noise,
@@ -97,7 +97,7 @@ Figure 3
 # `fig3_evidence_run`: Experiment for collecting detailed evidence values and sensor
 # data for one episode only. Used in `scripts/fig3.py` to generate evidence graphs
 # and visualize the path taken by the sensor/agent.
-fig3_evidence_run = deepcopy(dist_agent_1lm_heavy_noise)
+fig3_evidence_run = deepcopy(dist_agent_1lm_noise_all)
 fig3_evidence_run.update(
     dict(
         experiment_args=EvalExperimentArgs(

--- a/monty/configs/visualizations.py
+++ b/monty/configs/visualizations.py
@@ -54,7 +54,7 @@ from .common import (
     SelectiveEvidenceHandler,
     SelectiveEvidenceLoggingConfig,
 )
-from .fig3_robust_sensorimotor_inference import dist_agent_1lm
+from .fig3_robust_sensorimotor_inference import dist_agent_1lm_noise
 from .fig5_rapid_inference_with_voting import (
     dist_agent_1lm_randrot_noise,
     dist_agent_8lm_randrot_noise,
@@ -97,7 +97,7 @@ Figure 3
 # `fig3_evidence_run`: Experiment for collecting detailed evidence values and sensor
 # data for one episode only. Used in `scripts/fig3.py` to generate evidence graphs
 # and visualize the path taken by the sensor/agent.
-fig3_evidence_run = deepcopy(dist_agent_1lm)
+fig3_evidence_run = deepcopy(dist_agent_1lm_noise)
 fig3_evidence_run.update(
     dict(
         experiment_args=EvalExperimentArgs(

--- a/monty/configs/visualizations.py
+++ b/monty/configs/visualizations.py
@@ -54,7 +54,7 @@ from .common import (
     SelectiveEvidenceHandler,
     SelectiveEvidenceLoggingConfig,
 )
-from .fig3_robust_sensorimotor_inference import dist_agent_1lm_noise
+from .fig3_robust_sensorimotor_inference import dist_agent_1lm_heavy_noise
 from .fig5_rapid_inference_with_voting import (
     dist_agent_1lm_randrot_noise,
     dist_agent_8lm_randrot_noise,
@@ -97,7 +97,7 @@ Figure 3
 # `fig3_evidence_run`: Experiment for collecting detailed evidence values and sensor
 # data for one episode only. Used in `scripts/fig3.py` to generate evidence graphs
 # and visualize the path taken by the sensor/agent.
-fig3_evidence_run = deepcopy(dist_agent_1lm_noise)
+fig3_evidence_run = deepcopy(dist_agent_1lm_heavy_noise)
 fig3_evidence_run.update(
     dict(
         experiment_args=EvalExperimentArgs(


### PR DESCRIPTION
This PR is both a fix and a feature.

### Fix
Non-location noise parameters need to go into their own "features" dictionary. They are currently specified at the same level as "location" and are being ignored.

So this:
```python
    noise_params = {
        "pose_vectors": 2.0,
        "hsv": 0.1,
        "principal_curvatures_log": 0.1,
        "pose_fully_defined": 0.01,        
        "location": 0.002,
    }
```
needs to be this
```python
    noise_params = {
        "features": {
            "pose_vectors": 2.0,
            "hsv": 0.1,
            "principal_curvatures_log": 0.1,
            "pose_fully_defined": 0.01,
        },
        "location": 0.002,
    }
```
### Features
- Noise parameters are no longer universal across experiments. Figure 3 (robustness) experiments use one set, and the remaining noisy experiments use a different set (location-only noise). To accommodate this, I refactored `add_sensor_noise` and other noise-adding function to accept noise parameters. Configs have been adjusted accordingly.
- We also have a new condition for figure 3 where HSV values are clamped. A sensor module subclass and a config were added for that.

Finally, I renamed some figure 3 experiments to have the `randrot_14` suffix instead of `randrot_all`. `randrot_all` always bugged me because, "all" with respect to what? There are just 14 of them. Also, figure 3 noise experiments have the `noise_all` suffix instead of just `noise` to distinguish them from the other noise experiments.