### PR TITLE
feat: Monty model parameter-counting script

### DIFF
--- a/count_params.py
+++ b/count_params.py
@@ -1,3 +1,11 @@
+# Copyright 2025 Thousand Brains Project
+#
+# Copyright may exist in Contributors' modifications
+# and/or contributions to the work.
+#
+# Use of this source code is governed by the MIT
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
 import os
 from pathlib import Path
 
@@ -6,77 +14,116 @@ import numpy as np
 
 import torch
 
+from torch_geometric.data import Data
+
 """
-Count the number of parameters in a Monty model.
+This script counts the number of floating point parameters in a Monty model.
 
-The Monty model considers of a series of learned graphs, which are started in nested
-dictionaries like:
-graph = state_dict["lm_dict"][lm_id]["graph_memory"]["mug"][f"patch_{lm_id}"]
+The Monty model consists of a series of learned graphs for different objects. These are
+stored in a nested state dictionary, e.g.:
 
-A typical graph has the following structure:
-'hammer': {'patch': Data(
-  x=[1188, 28],
-  pos=[1188, 3],
-  norm=[1188, 3],
-  feature_mapping={
-    node_ids=[2],
-    pose_vectors=[2],
-    pose_fully_defined=[2],
-    on_object=[2],
-    object_coverage=[2],
-    rgba=[2],
-    hsv=[2],
-    principal_curvatures=[2],
-    principal_curvatures_log=[2],
-    gaussian_curvature=[2],
-    mean_curvature=[2],
-    gaussian_curvature_sc=[2],
-    mean_curvature_sc=[2]
-  },
-  edge_index=[2, 13068],
-  edge_attr=[13068, 3]
-)},
+    graph = state_dict["lm_dict"][lm_id]["graph_memory"]["mug"]["patch"]
 
-We want to account for all of the features stored at every point
-in the graph.
+We begin by breaking down the structure of the state dictionary.
 
-In particular, we need to count all of the floating point parameters, including e.g.
-within pose_vectors, there will be 2x arrays of 3 floats each. All values are either
-Python floats or numpy arrays. 
+A Monty models' state_dict contains the following keys:
+- 'lm_dict'
+- 'sm_dict'
+- 'motor_system_dict'
+- 'lm_to_lm_matrix'
+- 'lm_to_lm_vote_matrix'
+- 'sm_to_lm_matrix'
 
-The exception is edges, which we can ignore.
+All of the information we are concerned with is in lm_dict. sm_dict and
+motor_system_dict contain information for logging and visualization purposes. The
+connectivity information in lm_to_lm_matrix, lm_to_lm_vote_matrix, and sm_to_lm_matrix
+is a negligible fraction of data, particularly in single-LM models.
+
+Within lm_dict, lm_id is the index of the Learning Module(s), of which only 0 is
+relevant for single-LM models.lm_dict does not contain any other keys.
+
+state_dict["lm_dict"][lm_id] contains:
+- 'graph_memory'
+- 'target_to_graph_id'
+- 'graph_id_to_target'
+The latter two are mappings between the object name and the index of the graph, and
+are of negligible size.
+
+state_dict["lm_dict"][lm_id]["graph_memory"] contains keys corresponding
+to all of the learned objects (e.g. 77 in the case of YCB). Each graphs data object
+is associated with a key corresponding to the sensory channel that was used to learn the
+object. This is typically "patch", but could be indexed (e.g. "patch_0", "patch_1") in
+multi-LM (hierarchical or voting) models.
+
+A typical graph (accessed therefore with e.g.
+state_dict["lm_dict"][lm_id]["graph_memory"]["hammer"]["patch"]) has the following
+structure. Note the graph is a torch_geometric Data object.
+
+Data(
+    x=[1188, 28],  # 28 features per node; not all of these are used in inference,
+    # but for simplicity we count all of them.
+    pos=[1188, 3],  # Position of each node in an object's reference frame
+    norm=[1188, 3],  # The norm of each node; this is redundant with the norm in x
+
+    # feature_mapping stores the mapping between the array indices, and the features
+    # they represent. For example, pose_vectors has values 1, 10, indicating that
+    # indices 1:10 in x store the pose vectors of the node. These are stored as utility
+    # variables as Monty frequently switches between using the full x array, vs indexing
+    # individual values.
+    feature_mapping={
+        node_ids=[2],
+        pose_vectors=[2],
+        pose_fully_defined=[2],
+        on_object=[2],
+        object_coverage=[2],
+        rgba=[2],
+        hsv=[2],
+        principal_curvatures=[2],
+        principal_curvatures_log=[2],
+        gaussian_curvature=[2],
+        mean_curvature=[2],
+        gaussian_curvature_sc=[2],
+        mean_curvature_sc=[2]
+    },
+
+    # Edges are not used in Monty models at the moment and so can be ignored.
+    edge_index=[2, 13068],
+    edge_attr=[13068, 3]
+)
 """
 
-# Environment variables.
-# Define the root directory for DMC (DeepMind Control) related files
-# 1. os.environ.get("DMC_ROOT_DIR", "~/tbp/results/dmc") - Get the value of the DMC_ROOT_DIR 
-#    environment variable, or use "~/tbp/results/dmc" as the default if not set
-# 2. Path(...) - Convert the string to a Path object for better path manipulation
-# 3. .expanduser() - Expand the tilde (~) in the path to the user's home directory
+# Get the value of the DMC_ROOT_DIR environment variable, or use "~/tbp/results/dmc" as
+# the default if not set
 DMC_ROOT_DIR = Path(os.environ.get("DMC_ROOT_DIR", "~/tbp/results/dmc")).expanduser()
+# We use the single-LM, distant-agent model as an example.
+SINGLE_LM_MODEL_PATH = DMC_ROOT_DIR / "pretrained_models/dist_agent_1lm/pretrained/model.pt"
+SENSORY_CHANNEL = "patch"
+LM_ID = 0
 
-model_path = DMC_ROOT_DIR / "pretrained_models/dist_agent_1lm/pretrained/model.pt"
+# Count the number of parameters in the model
+def count_params(graph_memory):
+    total_params = 0
+    # Iterate through the learned objects
+    for object_data in graph_memory.values():
+        torch_geometric_data = object_data[SENSORY_CHANNEL]
 
-# Use pprint to understand the structure of the model, without printing all of the
-# actual parameters.
-state_dict = torch.load(model_path)
-# pprint.pprint(state_dict)
+        total_params += torch_geometric_data.x.numel()
+        total_params += torch_geometric_data.pos.numel()
 
+        # Each feature mapping key has two values (the upper and lower bounds of the
+        # indices in the x array that store the feature).
+        total_params += len(torch_geometric_data.feature_mapping.keys())*2
 
-sample_graph = state_dict["lm_dict"][0]["graph_memory"]["mug"]["patch"]
+        # Due to redundancy/not being used, norm and edge_index/edge_attr are not
+        # counted.
 
-print(sample_graph)
-# Access attributes directly from the Data object
-print("Feature mapping keys:", sample_graph.feature_mapping.keys())
+    return total_params
 
-for key in sample_graph.feature_mapping.keys():
-    print("\nValue of", key)
-    print(sample_graph.feature_mapping[key])
+if __name__ == "__main__":
+    # Load the model
+    graph_memory = torch.load(SINGLE_LM_MODEL_PATH)["lm_dict"][LM_ID]["graph_memory"]
 
-# Assuming 'pose_vectors' is a direct attribute holding the tensor data
-# (as is common in torch_geometric Data objects, alongside 'x', 'pos', etc.)
-# If pose_vectors data is stored elsewhere (e.g., sliced from 'x' based on feature_mapping),
-# this would need adjustment based on how the Data object was constructed.
-# However, accessing direct attributes is the standard way.
-print("Shape of pose_vectors:", len(sample_graph.feature_mapping["pose_vectors"]))
-print("Pose vectors:", sample_graph.feature_mapping["pose_vectors"])
+    total_params = count_params(graph_memory)
+    print(f"Total number of parameters: {total_params}")
+
+    print(f"\nIn millions: {total_params / 1e6:.2f}M")

--- a/count_params.py
+++ b/count_params.py
@@ -9,22 +9,21 @@
 import os
 from pathlib import Path
 
-import pprint
-import numpy as np
-
 import torch
 
-from torch_geometric.data import Data
-
 """
-This script counts the number of floating point parameters in a Monty model.
+This script counts the number of parameters in a Monty model, specifically the
+dist_agent_1lm model.
 
-The Monty model consists of a series of learned graphs for different objects. These are
-stored in a nested state dictionary, e.g.:
+The Monty model consists of a series of learned graphs for different objects. These
+are stored in a nested state dictionary, e.g.:
 
     graph = state_dict["lm_dict"][lm_id]["graph_memory"]["mug"]["patch"]
 
-We begin by breaking down the structure of the state dictionary.
+This script will count all the numerical values stored in these graphs, as a measure
+of the total number of parameters in the model.
+
+For clarity, we begin by breaking down the structure of the state dictionary.
 
 A Monty models' state_dict contains the following keys:
 - 'lm_dict'
@@ -40,33 +39,37 @@ connectivity information in lm_to_lm_matrix, lm_to_lm_vote_matrix, and sm_to_lm_
 is a negligible fraction of data, particularly in single-LM models.
 
 Within lm_dict, lm_id is the index of the Learning Module(s), of which only 0 is
-relevant for single-LM models.lm_dict does not contain any other keys.
+relevant for single-LM models. lm_dict does not contain any other keys.
 
 state_dict["lm_dict"][lm_id] contains:
 - 'graph_memory'
 - 'target_to_graph_id'
 - 'graph_id_to_target'
-The latter two are mappings between the object name and the index of the graph, and
-are of negligible size.
+The latter two are mappings between the object name and the index of the graph, which
+are needed to assess the performance of the model. They are of negligible size.
 
 state_dict["lm_dict"][lm_id]["graph_memory"] contains keys corresponding
-to all of the learned objects (e.g. 77 in the case of YCB). Each graphs data object
+to all of the learned objects (e.g. 77 in the case of YCB).
+
+Each graph key (e.g. state_dict["lm_dict"][lm_id]["graph_memory"]["hammer"])
 is associated with a key corresponding to the sensory channel that was used to learn the
 object. This is typically "patch", but could be indexed (e.g. "patch_0", "patch_1") in
 multi-LM (hierarchical or voting) models.
 
-A typical graph (accessed therefore with e.g.
-state_dict["lm_dict"][lm_id]["graph_memory"]["hammer"]["patch"]) has the following
-structure. Note the graph is a torch_geometric Data object.
+A typical graph can therefore be accessed with e.g.
+state_dict["lm_dict"][lm_id]["graph_memory"]["hammer"]["patch"].
+
+The accessed graph is a torch_geometric Data object, which has the following structure:
 
 Data(
     x=[1188, 28],  # 28 features per node; not all of these are used in inference,
     # but for simplicity we count all of them.
     pos=[1188, 3],  # Position of each node in an object's reference frame
-    norm=[1188, 3],  # The norm of each node; this is redundant with the norm in x
+    norm=[1188, 3],  # The norm of each node; this is redundant with the norm in x,
+    # and is in general never accessed directly during inference.
 
     # feature_mapping stores the mapping between the array indices, and the features
-    # they represent. For example, pose_vectors has values 1, 10, indicating that
+    # they represent. For example, "pose_vectors" has values [1, 10], indicating that
     # indices 1:10 in x store the pose vectors of the node. These are stored as utility
     # variables as Monty frequently switches between using the full x array, vs indexing
     # individual values.
@@ -95,14 +98,25 @@ Data(
 # Get the value of the DMC_ROOT_DIR environment variable, or use "~/tbp/results/dmc" as
 # the default if not set
 DMC_ROOT_DIR = Path(os.environ.get("DMC_ROOT_DIR", "~/tbp/results/dmc")).expanduser()
-# We use the single-LM, distant-agent model as an example.
-SINGLE_LM_MODEL_PATH = DMC_ROOT_DIR / "pretrained_models/dist_agent_1lm/pretrained/model.pt"
+# We use the single-LM, distant-agent model.
+SINGLE_LM_MODEL_PATH = (DMC_ROOT_DIR /
+                        "pretrained_models/dist_agent_1lm/pretrained/model.pt")
 SENSORY_CHANNEL = "patch"
 LM_ID = 0
 
-# Count the number of parameters in the model
-def count_params(graph_memory):
+def count_monty_model_params(graph_memory: dict) -> int:
+    """
+    Count the number of parameters in a Monty model.
+
+    Args:
+        graph_memory (dict): The graph memory dictionary of the model.
+
+    Returns:
+        The total number of parameters in the model.
+    """
+
     total_params = 0
+
     # Iterate through the learned objects
     for object_data in graph_memory.values():
         torch_geometric_data = object_data[SENSORY_CHANNEL]
@@ -123,7 +137,7 @@ if __name__ == "__main__":
     # Load the model
     graph_memory = torch.load(SINGLE_LM_MODEL_PATH)["lm_dict"][LM_ID]["graph_memory"]
 
-    total_params = count_params(graph_memory)
+    total_params = count_monty_model_params(graph_memory)
     print(f"Total number of parameters: {total_params}")
 
     print(f"\nIn millions: {total_params / 1e6:.2f}M")

--- a/count_params.py
+++ b/count_params.py
@@ -1,0 +1,82 @@
+import os
+from pathlib import Path
+
+import pprint
+import numpy as np
+
+import torch
+
+"""
+Count the number of parameters in a Monty model.
+
+The Monty model considers of a series of learned graphs, which are started in nested
+dictionaries like:
+graph = state_dict["lm_dict"][lm_id]["graph_memory"]["mug"][f"patch_{lm_id}"]
+
+A typical graph has the following structure:
+'hammer': {'patch': Data(
+  x=[1188, 28],
+  pos=[1188, 3],
+  norm=[1188, 3],
+  feature_mapping={
+    node_ids=[2],
+    pose_vectors=[2],
+    pose_fully_defined=[2],
+    on_object=[2],
+    object_coverage=[2],
+    rgba=[2],
+    hsv=[2],
+    principal_curvatures=[2],
+    principal_curvatures_log=[2],
+    gaussian_curvature=[2],
+    mean_curvature=[2],
+    gaussian_curvature_sc=[2],
+    mean_curvature_sc=[2]
+  },
+  edge_index=[2, 13068],
+  edge_attr=[13068, 3]
+)},
+
+We want to account for all of the features stored at every point
+in the graph.
+
+In particular, we need to count all of the floating point parameters, including e.g.
+within pose_vectors, there will be 2x arrays of 3 floats each. All values are either
+Python floats or numpy arrays. 
+
+The exception is edges, which we can ignore.
+"""
+
+# Environment variables.
+# Define the root directory for DMC (DeepMind Control) related files
+# 1. os.environ.get("DMC_ROOT_DIR", "~/tbp/results/dmc") - Get the value of the DMC_ROOT_DIR 
+#    environment variable, or use "~/tbp/results/dmc" as the default if not set
+# 2. Path(...) - Convert the string to a Path object for better path manipulation
+# 3. .expanduser() - Expand the tilde (~) in the path to the user's home directory
+DMC_ROOT_DIR = Path(os.environ.get("DMC_ROOT_DIR", "~/tbp/results/dmc")).expanduser()
+
+model_path = DMC_ROOT_DIR / "pretrained_models/dist_agent_1lm/pretrained/model.pt"
+
+# Use pprint to understand the structure of the model, without printing all of the
+# actual parameters.
+state_dict = torch.load(model_path)
+# pprint.pprint(state_dict)
+
+
+sample_graph = state_dict["lm_dict"][0]["graph_memory"]["mug"]["patch"]
+
+print(sample_graph)
+# Access attributes directly from the Data object
+print("Feature mapping keys:", sample_graph.feature_mapping.keys())
+
+for key in sample_graph.feature_mapping.keys():
+    print("\nValue of", key)
+    print(sample_graph.feature_mapping[key])
+
+# Assuming 'pose_vectors' is a direct attribute holding the tensor data
+# (as is common in torch_geometric Data objects, alongside 'x', 'pos', etc.)
+# If pose_vectors data is stored elsewhere (e.g., sliced from 'x' based on feature_mapping),
+# this would need adjustment based on how the Data object was constructed.
+# However, accessing direct attributes is the standard way.
+print("Shape of pose_vectors:", len(sample_graph.feature_mapping["pose_vectors"]))
+print("Pose vectors:", sample_graph.feature_mapping["pose_vectors"])

--- a/scripts/count_monty_params.py
+++ b/scripts/count_monty_params.py
@@ -13,7 +13,8 @@ import torch
 
 """
 This script counts the number of parameters in a Monty model, specifically the
-dist_agent_1lm model.
+dist_agent_1lm model. This is a result (4 million parameters) referenced in the
+Continual Learning section of the paper.
 
 The Monty model consists of a series of learned graphs for different objects. These
 are stored in a nested state dictionary, e.g.:

--- a/scripts/count_monty_params.py
+++ b/scripts/count_monty_params.py
@@ -105,6 +105,7 @@ SINGLE_LM_MODEL_PATH = (DMC_ROOT_DIR /
 SENSORY_CHANNEL = "patch"
 LM_ID = 0
 
+
 def count_monty_model_params(graph_memory: dict) -> int:
     """
     Count the number of parameters in a Monty model.
@@ -127,12 +128,13 @@ def count_monty_model_params(graph_memory: dict) -> int:
 
         # Each feature mapping key has two values (the upper and lower bounds of the
         # indices in the x array that store the feature).
-        total_params += len(torch_geometric_data.feature_mapping.keys())*2
+        total_params += len(torch_geometric_data.feature_mapping.keys()) * 2
 
         # Due to redundancy/not being used, norm and edge_index/edge_attr are not
         # counted.
 
     return total_params
+
 
 if __name__ == "__main__":
     # Load the model

--- a/scripts/count_monty_params.py
+++ b/scripts/count_monty_params.py
@@ -6,13 +6,8 @@
 # Use of this source code is governed by the MIT
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
-import os
-from pathlib import Path
 
-import torch
-
-"""
-This script counts the number of parameters in a Monty model, specifically the
+"""This script counts the number of parameters in a Monty model, specifically the
 dist_agent_1lm model. This is a result (4 million parameters) referenced in the
 Continual Learning section of the paper.
 
@@ -95,6 +90,11 @@ Data(
     edge_attr=[13068, 3]
 )
 """
+
+import os
+from pathlib import Path
+
+import torch
 
 # Get the value of the DMC_ROOT_DIR environment variable, or use "~/tbp/results/dmc" as
 # the default if not set

--- a/scripts/count_monty_params.py
+++ b/scripts/count_monty_params.py
@@ -142,5 +142,8 @@ if __name__ == "__main__":
 
     total_params = count_monty_model_params(graph_memory)
 
-    print(f"Total number of parameters: {total_params}")
-    print(f"\nIn millions: {total_params / 1e6:.0f}M")
+    print("Monty Model Parameter Count")
+    print(f" - Model: {DIST_AGENT_1LM_MODEL_PATH}")
+    print(f" - Sensory Channel: '{SENSORY_CHANNEL}'")
+    print(f" - LM ID: {LM_ID}")
+    print(f" - Total number of parameters: {total_params} (~{total_params / 1e6:.0f}M)")

--- a/scripts/count_monty_params.py
+++ b/scripts/count_monty_params.py
@@ -64,11 +64,11 @@ Data(
     norm=[1188, 3],  # The norm of each node; this is redundant with the norm in x,
     # and is in general never accessed directly during inference.
 
-    # feature_mapping stores the mapping between the array indices, and the features
-    # they represent. For example, "pose_vectors" has values [1, 10], indicating that
-    # indices 1:10 in x store the pose vectors of the node. These are stored as utility
-    # variables as Monty frequently switches between using the full x array, vs indexing
-    # individual values.
+    # feature_mapping stores the mapping between the array indices in x, and the
+    # features they represent. For example, "pose_vectors" has values [1, 10],
+    # indicating that indices 1:10 in x store the pose vectors of the node. These are
+    # stored as utility variables as Monty frequently switches between using the full x
+    # array, vs indexing individual values.
     feature_mapping={
         node_ids=[2],
         pose_vectors=[2],

--- a/scripts/count_monty_params.py
+++ b/scripts/count_monty_params.py
@@ -100,7 +100,7 @@ import torch
 from data_utils import DMC_ROOT_DIR
 
 # We use the single-LM, distant-agent model.
-SINGLE_LM_MODEL_PATH = (DMC_ROOT_DIR /
+DIST_AGENT_1LM_MODEL_PATH = (DMC_ROOT_DIR /
                         "pretrained_models/dist_agent_1lm/pretrained/model.pt")
 SENSORY_CHANNEL = "patch"
 LM_ID = 0

--- a/scripts/count_monty_params.py
+++ b/scripts/count_monty_params.py
@@ -135,7 +135,7 @@ def count_monty_model_params(graph_memory: dict) -> int:
 
 
 if __name__ == "__main__":
-    graph_memory = torch.load(SINGLE_LM_MODEL_PATH)["lm_dict"][LM_ID]["graph_memory"]
+    graph_memory = torch.load(DIST_AGENT_1LM_MODEL_PATH)["lm_dict"][LM_ID]["graph_memory"]
 
     total_params = count_monty_model_params(graph_memory)
 

--- a/scripts/count_monty_params.py
+++ b/scripts/count_monty_params.py
@@ -105,11 +105,13 @@ DIST_AGENT_1LM_MODEL_PATH = (DMC_ROOT_DIR /
 SENSORY_CHANNEL = "patch"
 LM_ID = 0
 
-def count_monty_model_params(graph_memory: dict) -> int:
+def count_monty_model_params(graph_memory: dict, sensory_channel: str) -> int:
     """Count the number of parameters in a Monty model.
 
     Args:
         graph_memory (dict): The graph memory dictionary of the model.
+        sensory_channel (str): The sensory channel for the learned graphs that we want
+            to count the parameters for.
 
     Returns:
         The total number of parameters in the model.
@@ -119,7 +121,7 @@ def count_monty_model_params(graph_memory: dict) -> int:
 
     # Iterate through the learned objects
     for object_data in graph_memory.values():
-        torch_geometric_data = object_data[SENSORY_CHANNEL]
+        torch_geometric_data = object_data[sensory_channel]
 
         total_params += torch_geometric_data.x.numel()
         total_params += torch_geometric_data.pos.numel()
@@ -137,7 +139,7 @@ def count_monty_model_params(graph_memory: dict) -> int:
 if __name__ == "__main__":
     graph_memory = torch.load(DIST_AGENT_1LM_MODEL_PATH)["lm_dict"][LM_ID]["graph_memory"]
 
-    total_params = count_monty_model_params(graph_memory)
+    total_params = count_monty_model_params(graph_memory, SENSORY_CHANNEL)
 
     print("Monty Model Parameter Count")
     print(f" - Model: {DIST_AGENT_1LM_MODEL_PATH}")

--- a/scripts/count_monty_params.py
+++ b/scripts/count_monty_params.py
@@ -108,8 +108,7 @@ SENSORY_CHANNEL = "patch"
 LM_ID = 0
 
 def count_monty_model_params(graph_memory: dict) -> int:
-    """
-    Count the number of parameters in a Monty model.
+    """Count the number of parameters in a Monty model.
 
     Args:
         graph_memory (dict): The graph memory dictionary of the model.

--- a/scripts/count_monty_params.py
+++ b/scripts/count_monty_params.py
@@ -141,4 +141,4 @@ if __name__ == "__main__":
     total_params = count_monty_model_params(graph_memory)
 
     print(f"Total number of parameters: {total_params}")
-    print(f"\nIn millions: {total_params / 1e6:.2f}M")
+    print(f"\nIn millions: {total_params / 1e6:.0f}M")

--- a/scripts/count_monty_params.py
+++ b/scripts/count_monty_params.py
@@ -44,7 +44,7 @@ state_dict["lm_dict"][lm_id] contains:
 - 'target_to_graph_id'
 - 'graph_id_to_target'
 The latter two are mappings between the object name and the index of the graph, which
-are needed to assess the performance of the model. They are of negligible size.
+are needed to assess the performance of the model. 
 
 state_dict["lm_dict"][lm_id]["graph_memory"] contains keys corresponding
 to all of the learned objects (e.g. 77 in the case of YCB).

--- a/scripts/count_monty_params.py
+++ b/scripts/count_monty_params.py
@@ -93,14 +93,12 @@ Data(
 )
 """
 
-import os
-from pathlib import Path
-
 import torch
 
 # Get the value of the DMC_ROOT_DIR environment variable, or use "~/tbp/results/dmc" as
-# the default if not set
-DMC_ROOT_DIR = Path(os.environ.get("DMC_ROOT_DIR", "~/tbp/results/dmc")).expanduser()
+# the default if not set.
+from data_utils import DMC_ROOT_DIR
+
 # We use the single-LM, distant-agent model.
 SINGLE_LM_MODEL_PATH = (DMC_ROOT_DIR /
                         "pretrained_models/dist_agent_1lm/pretrained/model.pt")

--- a/scripts/count_monty_params.py
+++ b/scripts/count_monty_params.py
@@ -7,8 +7,10 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-"""This script counts the number of parameters in a Monty model, specifically the
-dist_agent_1lm model. This is a result (4 million parameters) referenced in the
+"""Count the number of parameters in the `dist_agent_1lm`  Monty model.
+
+This script counts the number of parameters in a Monty model, specifically the
+`dist_agent_1lm` pretrained model. This produces the result (4 million parameters) referenced in the
 Continual Learning section of the paper.
 
 The Monty model consists of a series of learned graphs for different objects. These

--- a/scripts/count_monty_params.py
+++ b/scripts/count_monty_params.py
@@ -21,7 +21,7 @@ of the total number of parameters in the model.
 
 For clarity, we begin by breaking down the structure of the state dictionary.
 
-A Monty models' state_dict contains the following keys:
+A Monty model's state_dict contains the following keys:
 - 'lm_dict'
 - 'sm_dict'
 - 'motor_system_dict'
@@ -52,7 +52,7 @@ is associated with a key corresponding to the sensory channel that was used to l
 object. This is typically "patch", but could be indexed (e.g. "patch_0", "patch_1") in
 multi-LM (hierarchical or voting) models.
 
-A typical graph can therefore be accessed with e.g.
+A graph can therefore be accessed with e.g.
 state_dict["lm_dict"][lm_id]["graph_memory"]["hammer"]["patch"].
 
 The accessed graph is a torch_geometric Data object, which has the following structure:
@@ -105,7 +105,6 @@ SINGLE_LM_MODEL_PATH = (DMC_ROOT_DIR /
 SENSORY_CHANNEL = "patch"
 LM_ID = 0
 
-
 def count_monty_model_params(graph_memory: dict) -> int:
     """
     Count the number of parameters in a Monty model.
@@ -137,10 +136,9 @@ def count_monty_model_params(graph_memory: dict) -> int:
 
 
 if __name__ == "__main__":
-    # Load the model
     graph_memory = torch.load(SINGLE_LM_MODEL_PATH)["lm_dict"][LM_ID]["graph_memory"]
 
     total_params = count_monty_model_params(graph_memory)
-    print(f"Total number of parameters: {total_params}")
 
+    print(f"Total number of parameters: {total_params}")
     print(f"\nIn millions: {total_params / 1e6:.2f}M")


### PR DESCRIPTION
Adds a simple script to calculate the number of parameters of a Monty model, supporting one of the statements in the paper.

Assumptions etc. should all be clear in the doc string, but let me know if I can clarify anything. 

This might eventually be a useful mini-tutorial or the like, as I think it gives a helpful intuition of what a Monty model actually "is".