### PR TITLE
feat: project setup files for vit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,3 @@
-.vscode/
-sandbox/
-output_last.log
-
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/pytorch/.gitignore
+++ b/pytorch/.gitignore
@@ -1,0 +1,154 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+### VisualStudioCode
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+*.code-workspace
+**/.vscode
+
+# JetBrains
+.idea/
+
+# Data & Models
+*.h5
+*.tar
+*.tar.gz
+
+# Lightning-Hydra-Template
+configs/local/default.yaml
+/data/
+/logs/
+.env
+
+# Aim logging
+.aim

--- a/pytorch/.project-root
+++ b/pytorch/.project-root
@@ -1,0 +1,2 @@
+# this file is required for inferring the project root directory
+# do not delete

--- a/pytorch/environment.yaml
+++ b/pytorch/environment.yaml
@@ -1,0 +1,34 @@
+name: vit
+
+channels:
+  - pytorch
+  - conda-forge
+  - defaults
+
+dependencies:
+  - python=3.12
+  # --------- pytorch --------- #
+  - pytorch>=2.0.0
+  - torchvision>=0.15.0
+  - lightning>=2.0.0
+  - torchmetrics>=0.11.4
+
+  # --------- hydra --------- #
+  - hydra-core=1.3.2
+  - rich=13.*            # beautiful text formatting in terminal
+  - pre-commit=3.*       # hooks for applying linters on commit
+  - pytest=7.*           # tests
+  - scikit-learn
+  - transformers
+  - einops
+  - pandas
+
+  # --------- loggers --------- #
+  - wandb
+  - pip>=23
+  - pip:
+      - hydra-optuna-sweeper==1.2.0
+      - hydra-colorlog==1.2.0
+      - rootutils         # standardizing the project root setup
+      - calflops
+      - matplotlib

--- a/pytorch/pyproject.toml
+++ b/pytorch/pyproject.toml
@@ -1,0 +1,36 @@
+[tool.ruff]
+line-length = 99
+exclude = [
+  ".bzr",
+  ".direnv",
+  ".eggs",
+  ".git",
+  ".git-rewrite",
+  ".hg",
+  ".mypy_cache",
+  ".nox",
+  ".pants.d",
+  ".pytype",
+  ".ruff_cache",
+  ".svn",
+  ".tox",
+  ".venv",
+  "__pypackages__",
+  "_build",
+  "buck-out",
+  "build",
+  "dist",
+  "node_modules",
+  "venv",
+]
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "W"]
+fixable = ["ALL"]
+unfixable = []
+
+[tool.ruff.lint.isort]
+known-first-party = ["benchmark_vit"]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 10


### PR DESCRIPTION
Not related to ViT core logic but important for creating conda environment. The .gitignore is the same as PR #24 (it will not have it in the future once #24 is merged), so please ignore that.

The only unusual file may be `.project-root`. The purpose of this file is to indicate where the root folder of the project is based on where this file is located (using the package `rootutils`, but mostly exists because I based the vit project using the `lightning-hydra-template` (https://github.com/ashleve/lightning-hydra-template). If I remember correctly, I think this helped with imports without having to pip install the folder as a package. There are probably other ways, but it was just easier to use existing solution. 