### PR TITLE
Update descriptions of figure 5 and 6 order

### DIFF
--- a/monty/configs/README.md
+++ b/monty/configs/README.md
@@ -61,6 +61,9 @@ This captures core model performance in a realistic setting.
 
 ## Figure 5: Rapid Inference with Voting
 
+Note in our final paper, these results appear in the "Figure 6", after "Rapid Inference
+with Model-Free and Model-Based Policies"
+
 Consists of 5 experiments:
 - `dist_agent_1lm_randrot_noise`
 - `dist_agent_2lm_randrot_noise`
@@ -82,6 +85,9 @@ Performance is evaluated on:
 The main output measure is accuracy and rotation error as a function of the number of LMs.
 
 ## Figure 6: Rapid Inference with Model-Free and Model-Based Policies
+
+Note in our final paper, these results appear in the "Figure 5", before "Rapid Inference
+with Voting"
 
 Consists of 3 experiments:
 - `dist_agent_1lm_randrot_noise_nohyp` - No hypothesis-testing, and random-walk policy

--- a/monty/configs/fig5_rapid_inference_with_voting.py
+++ b/monty/configs/fig5_rapid_inference_with_voting.py
@@ -25,6 +25,9 @@ All of these experiments use:
  - Sensor noise and 5 (predefined) random rotations
  - Voting over 2, 4, 8, or 16 LM, and terminating when 2 LMs have converged.
 
+Note in our final paper, these results appear in the "Figure 6", after "Rapid Inference
+with Model-Free and Model-Based Policies".
+
 """
 
 from typing import Any, Mapping

--- a/monty/configs/fig6_rapid_inference_with_model_based_policies.py
+++ b/monty/configs/fig6_rapid_inference_with_model_based_policies.py
@@ -20,6 +20,9 @@ This module defines the following experiments:
  - No voting
  - Varying levels of hypothesis-testing
 
+Note in our final paper, these results appear in the "Figure 5", before "Rapid Inference
+with Voting".
+
 """
 
 from copy import deepcopy

--- a/scripts/fig5.py
+++ b/scripts/fig5.py
@@ -8,6 +8,9 @@
 # https://opensource.org/licenses/MIT.
 """This module defines functions used to generate images for figure 5.
 
+Note in our final paper, these results appear in the "Figure 6", after "Rapid Inference
+with Model-Free and Model-Based Policies".
+
 Panel B: 8-patch view finder
  - `plot_8lm_patches()`
 

--- a/scripts/fig6.py
+++ b/scripts/fig6.py
@@ -8,6 +8,9 @@
 # https://opensource.org/licenses/MIT.
 """This module defines functions used to generate images for figure 6.
 
+Note in our final paper, these results appear in the "Figure 5", before "Rapid Inference
+with Voting".
+
 Panel A: Curvature Guided Policy
  - `plot_curvature_guided_policy()`
 


### PR DESCRIPTION
Adds some comments to clarify the ordering of figures in the repository vs. the paper. I originally started actually re-ordering them, but it would lead to a lot of changes including to imports and what we have uploaded for visualizations etc., and likely benefit from re-testing all replications. This didn't seem worth the time given it is a pretty minor tweak that I think people will be able to easily understand if they're actually trying to replicate the paper.